### PR TITLE
Add digital time display and improved markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# clocktest
+# 24 Hour Clock Loader
+
+This is a simple web app that displays a 24-hour clock as a loading bar. The bar fills from left to right over the course of a day. A live digital clock is shown above the bar. Each hour is marked below the bar, and the marks (and numbers) at 3, 6, 9, 12, 15, 18, 21 and 24 are larger for better readability.
+
+Open `index.html` in your browser to see the clock in action. To share it publicly, push the files to a GitHub repository and enable GitHub Pages for that repo.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>24 Hour Clock Loader</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <div id="time-display"></div>
+        <div id="progress-bar">
+            <div id="progress"></div>
+        </div>
+        <div id="markers"></div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,40 @@
+function updateProgress() {
+    const now = new Date();
+    const hours = now.getHours();
+    const minutes = now.getMinutes();
+    const seconds = now.getSeconds();
+
+    const totalSeconds = hours * 3600 + minutes * 60 + seconds;
+    const progressPercent = (totalSeconds / 86400) * 100; // 24*60*60 = 86400
+    document.getElementById('progress').style.width = progressPercent + '%';
+
+    const timeString = now.toLocaleTimeString('en-US', { hour12: false });
+    document.getElementById('time-display').textContent = timeString;
+}
+
+function createMarkers() {
+    const markersContainer = document.getElementById('markers');
+    for (let i = 1; i <= 24; i++) {
+        const marker = document.createElement('div');
+        marker.classList.add('marker');
+        if (i % 3 === 0) {
+            marker.classList.add('marker-large');
+        } else {
+            marker.classList.add('marker-small');
+        }
+
+        const line = document.createElement('div');
+        line.classList.add('marker-line');
+        marker.appendChild(line);
+
+        const label = document.createElement('div');
+        label.textContent = i;
+        marker.appendChild(label);
+
+        markersContainer.appendChild(marker);
+    }
+}
+
+createMarkers();
+updateProgress();
+setInterval(updateProgress, 1000); // update every second

--- a/style.css
+++ b/style.css
@@ -1,0 +1,68 @@
+body {
+    background-color: #333;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    color: #fff;
+    font-family: Arial, sans-serif;
+    margin: 0;
+}
+
+.container {
+    width: 80%;
+    height: 50vh; /* half the page height */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+#progress-bar {
+    background-color: #444;
+    height: 50%;
+    position: relative;
+}
+
+#progress {
+    background-color: #ccc;
+    height: 100%;
+    width: 0%;
+}
+
+#markers {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 10px;
+    font-size: 12px;
+}
+
+#time-display {
+    text-align: center;
+    margin-bottom: 10px;
+    font-size: 1.2em;
+}
+
+.marker {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.marker-line {
+    width: 1px;
+    background: #fff;
+}
+
+.marker-large .marker-line {
+    height: 20px;
+    width: 2px;
+}
+
+.marker-small .marker-line {
+    height: 10px;
+}
+
+.marker-large label {
+    font-size: 1.1em;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- show current time above the loading bar
- enlarge markers and numbers every 3 hours
- style updates for marker labels
- document how to share via GitHub Pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ec7aa56ac8333a70d200ba4a1d1fe