### PR TITLE
Fix hour marker alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ function createMarkers() {
         } else {
             marker.classList.add('marker-small');
         }
+        marker.style.left = (i / 24) * 100 + '%';
 
         const line = document.createElement('div');
         line.classList.add('marker-line');

--- a/style.css
+++ b/style.css
@@ -30,8 +30,9 @@ body {
 }
 
 #markers {
-    display: flex;
-    justify-content: space-between;
+    position: relative;
+    width: 100%;
+    height: 30px;
     margin-top: 10px;
     font-size: 12px;
 }
@@ -43,6 +44,9 @@ body {
 }
 
 .marker {
+    position: absolute;
+    bottom: 0;
+    transform: translateX(-50%);
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Summary
- make markers container relative and absolutely position markers
- place marker positions based on hour fraction

## Testing
- `npx eslint script.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686ecaa5cc508333a82a81586d84adf6