### PR TITLE
Add edge-aligned markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 24 Hour Clock Loader
 
-This is a simple web app that displays a 24-hour clock as a loading bar. The bar fills from left to right over the course of a day. A live digital clock is shown above the bar. Each hour is marked below the bar, and the marks (and numbers) at 3, 6, 9, 12, 15, 18, 21 and 24 are larger for better readability.
+This is a simple web app that displays a 24-hour clock as a loading bar. The bar fills from left to right over the course of a day. A live digital clock is shown above the bar. Each hour is marked below the bar from 0 through 24. The marks (and numbers) at 0, 3, 6, 9, 12, 15, 18, 21 and 24 are twice the size for better readability and the 0/24 markers sit flush with the edges.
 
 Open `index.html` in your browser to see the clock in action. To share it publicly, push the files to a GitHub repository and enable GitHub Pages for that repo.

--- a/script.js
+++ b/script.js
@@ -14,13 +14,18 @@ function updateProgress() {
 
 function createMarkers() {
     const markersContainer = document.getElementById('markers');
-    for (let i = 1; i <= 24; i++) {
+    for (let i = 0; i <= 24; i++) {
         const marker = document.createElement('div');
         marker.classList.add('marker');
         if (i % 3 === 0) {
             marker.classList.add('marker-large');
         } else {
             marker.classList.add('marker-small');
+        }
+        if (i === 0) {
+            marker.classList.add('marker-start');
+        } else if (i === 24) {
+            marker.classList.add('marker-end');
         }
         marker.style.left = (i / 24) * 100 + '%';
 

--- a/style.css
+++ b/style.css
@@ -67,6 +67,14 @@ body {
 }
 
 .marker-large label {
-    font-size: 1.1em;
+    font-size: 2em;
     font-weight: bold;
+}
+
+.marker-start {
+    transform: none;
+}
+
+.marker-end {
+    transform: translateX(-100%);
 }


### PR DESCRIPTION
## Summary
- clarify README that the scale now runs from 0 to 24
- place 0 and 24 markers flush with the edges so labels aren't cut off
- keep enlarged major markers at every third hour

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ecc76d43c8333bf0f8ce3d1cf08b0