### PR TITLE
Add sound settings and hour progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,25 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <button id="settings-button">&#9881;</button>
+    <div id="settings-panel" class="hidden">
+        <div class="setting-row">
+            <label><input type="checkbox" id="hourly-ding"> Hourly ding</label>
+            <button id="test-hourly">Test</button>
+        </div>
+        <div class="setting-row">
+            <label><input type="checkbox" id="quarter-ding"> 15 minute click</label>
+            <button id="test-quarter">Test</button>
+        </div>
+        <div class="setting-row">
+            <label>Volume <input type="range" id="volume" min="0" max="1" step="0.01"></label>
+        </div>
+    </div>
     <div class="container">
         <div id="time-display"></div>
+        <div id="hour-progress-bar">
+            <div id="hour-progress"></div>
+        </div>
         <div id="progress-bar">
             <div id="progress"></div>
         </div>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,72 @@
+let hourlyDing = localStorage.getItem('hourlyDing') === 'true';
+let quarterDing = localStorage.getItem('quarterDing') === 'true';
+let volume = parseFloat(localStorage.getItem('volume')) || 0.5;
+let lastHourPlayed = null;
+let lastQuarterPlayed = null;
+
+const settingsButton = document.getElementById('settings-button');
+const settingsPanel = document.getElementById('settings-panel');
+const hourlyCheckbox = document.getElementById('hourly-ding');
+const quarterCheckbox = document.getElementById('quarter-ding');
+const volumeControl = document.getElementById('volume');
+
+settingsButton.addEventListener('click', () => {
+    settingsPanel.classList.toggle('visible');
+});
+
+hourlyCheckbox.checked = hourlyDing;
+quarterCheckbox.checked = quarterDing;
+volumeControl.value = volume;
+
+hourlyCheckbox.addEventListener('change', () => {
+    hourlyDing = hourlyCheckbox.checked;
+    localStorage.setItem('hourlyDing', hourlyDing);
+});
+
+quarterCheckbox.addEventListener('change', () => {
+    quarterDing = quarterCheckbox.checked;
+    localStorage.setItem('quarterDing', quarterDing);
+});
+
+volumeControl.addEventListener('input', () => {
+    volume = parseFloat(volumeControl.value);
+    localStorage.setItem('volume', volume);
+});
+
+document.getElementById('test-hourly').addEventListener('click', playDing);
+document.getElementById('test-quarter').addEventListener('click', playDoubleClick);
+
+function playDing() {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.setValueAtTime(880, ctx.currentTime);
+    gain.gain.value = volume;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + 0.5);
+}
+
+function playDoubleClick() {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    function click(time) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(660, time);
+        gain.gain.setValueAtTime(volume, time);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(time);
+        osc.stop(time + 0.1);
+    }
+    const now = ctx.currentTime;
+    click(now);
+    click(now + 0.2);
+}
+
 function updateProgress() {
     const now = new Date();
     const hours = now.getHours();
@@ -5,11 +74,24 @@ function updateProgress() {
     const seconds = now.getSeconds();
 
     const totalSeconds = hours * 3600 + minutes * 60 + seconds;
-    const progressPercent = (totalSeconds / 86400) * 100; // 24*60*60 = 86400
+    const progressPercent = (totalSeconds / 86400) * 100;
     document.getElementById('progress').style.width = progressPercent + '%';
+
+    const hourProgressPercent = ((minutes * 60 + seconds) / 3600) * 100;
+    document.getElementById('hour-progress').style.width = hourProgressPercent + '%';
 
     const timeString = now.toLocaleTimeString('en-US', { hour12: false });
     document.getElementById('time-display').textContent = timeString;
+
+    if (hourlyDing && minutes === 0 && seconds === 0 && hours !== lastHourPlayed) {
+        playDing();
+        lastHourPlayed = hours;
+    }
+    const quarter = Math.floor(minutes / 15);
+    if (quarterDing && minutes % 15 === 0 && seconds === 0 && quarter !== lastQuarterPlayed) {
+        playDoubleClick();
+        lastQuarterPlayed = quarter;
+    }
 }
 
 function createMarkers() {

--- a/style.css
+++ b/style.css
@@ -9,12 +9,58 @@ body {
     margin: 0;
 }
 
+#settings-button {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: #fff;
+    opacity: 0.3;
+    font-size: 1.5em;
+    cursor: pointer;
+}
+
+#settings-panel {
+    position: absolute;
+    top: 40px;
+    right: 10px;
+    background: rgba(0, 0, 0, 0.8);
+    padding: 10px;
+    display: none;
+    font-size: 0.9em;
+}
+
+#settings-panel.visible {
+    display: block;
+}
+
+.setting-row {
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 .container {
     width: 80%;
     height: 50vh; /* half the page height */
     display: flex;
     flex-direction: column;
     justify-content: center;
+}
+
+#hour-progress-bar {
+    background-color: #555;
+    height: 20%;
+    margin-bottom: 5px;
+    position: relative;
+}
+
+#hour-progress {
+    background-color: #999;
+    height: 100%;
+    width: 0%;
 }
 
 #progress-bar {


### PR DESCRIPTION
## Summary
- add a settings panel with opacity button
- implement hourly ding and 15‑minute click sounds with volume control
- add hour progress bar above the day bar

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686ece2123ec83338a25b5cb3c624eab