### PR TITLE
Adjust transition times for accent color and night filter

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,7 +29,7 @@ body, body * {
 }
 
 body::after {
-    transition: background-color 1.5s ease;
+    transition: background-color 0.4s ease;
     content: "";
     position: fixed;
     top: 0;
@@ -139,6 +139,9 @@ body.light-mode #color-slider-row {
     height: 100%;
     width: 0%;
     border-radius: 6px;
+}
+#progress, #hour-progress {
+    transition: background-color 0.4s ease;
 }
 
 #markers {


### PR DESCRIPTION
## Summary
- shorten transition for night filter overlay
- update progress bars to animate accent color in 0.4s

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ed8748108333ae531b823529f825