### PR TITLE
Enable accent color slider in both themes

### DIFF
--- a/script.js
+++ b/script.js
@@ -483,10 +483,20 @@ function updateHourNumbersVisibility() {
 }
 
 function updateAccentColor() {
-    if (lightMode) {
-        document.documentElement.style.setProperty('--progress-hue', progressHue);
-        document.documentElement.style.setProperty('--progress-saturation', progressSaturation + '%');
-    }
+    const color = `hsl(${progressHue}, ${progressSaturation}%, 50%)`;
+    document.documentElement.style.setProperty('--progress-hue', progressHue);
+    document.documentElement.style.setProperty('--progress-saturation', progressSaturation + '%');
+    document.documentElement.style.setProperty('--progress-color', color);
+    colorSlider.style.accentColor = color;
+    colorSlider.style.background = `linear-gradient(to right,
+        hsl(0, ${progressSaturation}%, 50%),
+        hsl(60, ${progressSaturation}%, 50%),
+        hsl(120, ${progressSaturation}%, 50%),
+        hsl(180, ${progressSaturation}%, 50%),
+        hsl(240, ${progressSaturation}%, 50%),
+        hsl(300, ${progressSaturation}%, 50%),
+        hsl(360, ${progressSaturation}%, 50%)
+    )`;
 }
 
 function updateNightFilter() {
@@ -496,13 +506,10 @@ function updateNightFilter() {
 function applyTheme() {
     if (lightMode) {
         document.body.classList.add('light-mode');
-        updateAccentColor();
     } else {
         document.body.classList.remove('light-mode');
-        document.documentElement.style.removeProperty('--progress-hue');
-        document.documentElement.style.removeProperty('--progress-saturation');
-        document.documentElement.style.removeProperty('--progress-color');
     }
+    updateAccentColor();
     updateNightFilter();
 }
 

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
     --settings-panel-bg: rgba(0, 0, 0, 0.8);
     --hour-progress-bar-bg: #555;
     --progress-bar-bg: #444;
-    --progress-color: #999;
+    --progress-color: hsl(var(--progress-hue), var(--progress-saturation), 50%);
     --progress-hue: 60;
     --progress-saturation: 50%;
     --marker-line-color: #fff;
@@ -51,7 +51,6 @@ body.light-mode {
     --hour-progress-bar-bg: #bbb;
     --progress-bar-bg: #ccc;
     --marker-line-color: #000;
-    --progress-color: hsl(var(--progress-hue), var(--progress-saturation), 50%);
 }
 
 #settings-button {
@@ -91,6 +90,19 @@ body.light-mode {
 #color-slider-row,
 #saturation-slider-row {
     display: flex;
+}
+
+#color-slider {
+    accent-color: hsl(var(--progress-hue), var(--progress-saturation), 50%);
+    background: linear-gradient(to right,
+        hsl(0deg, var(--progress-saturation), 50%),
+        hsl(60deg, var(--progress-saturation), 50%),
+        hsl(120deg, var(--progress-saturation), 50%),
+        hsl(180deg, var(--progress-saturation), 50%),
+        hsl(240deg, var(--progress-saturation), 50%),
+        hsl(300deg, var(--progress-saturation), 50%),
+        hsl(360deg, var(--progress-saturation), 50%)
+    );
 }
 
 .container {


### PR DESCRIPTION
## Summary
- support accent color selection in dark mode
- show hue gradient on the color slider

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_6883fab1ab608333963b0e61a6a92f6d