### PR TITLE
Fix color slider thumb color and flashing

### DIFF
--- a/style.css
+++ b/style.css
@@ -103,6 +103,14 @@ body.light-mode {
         hsl(300deg, var(--progress-saturation), 50%),
         hsl(360deg, var(--progress-saturation), 50%)
     );
+    transition: none;
+}
+
+#color-slider::-webkit-slider-thumb,
+#color-slider::-moz-range-thumb {
+    background: hsl(var(--progress-hue), var(--progress-saturation), 50%);
+    border: none;
+    transition: none;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- set color slider thumb to use selected hue
- remove transitions from the slider to avoid flashing

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883feea6dac833399e796e9b9e74487