### PR TITLE
Fix progress bar visibility and button style

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,6 +36,13 @@ body, body * {
     opacity: 1;
 }
 
+/* Allow marker containers to display content outside their bounds */
+#hour-progress-bar,
+#markers,
+#hour-markers {
+    overflow: visible;
+}
+
 .hidden-toggle {
     opacity: 0;
     max-height: 0;
@@ -76,6 +83,13 @@ body.light-mode {
     opacity: 0.3;
     font-size: 1.5em;
     cursor: pointer;
+    outline: none;
+}
+
+#settings-button:focus,
+#settings-button:active {
+    outline: none;
+    color: var(--settings-button-color);
 }
 
 #settings-panel {
@@ -164,7 +178,7 @@ body.light-mode {
     position: absolute;
     top: -25px;
     width: 100%;
-    height: 25px;
+    height: 30px;
     font-size: 12px;
 }
 
@@ -197,7 +211,7 @@ body.light-mode {
 #markers {
     position: relative;
     width: 100%;
-    height: 30px;
+    height: 40px;
     margin-top: 10px;
     font-size: 12px;
 }


### PR DESCRIPTION
## Summary
- allow overflow on progress bar containers so markers display correctly
- tweak settings button focus styles
- enlarge marker areas to prevent number clipping

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68841a13cbbc8333ad448b4cec39d644